### PR TITLE
Fix internal links in tutorial

### DIFF
--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -22,9 +22,9 @@
         <div class="span3 sidebar">
           <div data-spy="affix" data-offset-bottom="290">
             <ul class="nav nav-list sidenav">
-              <li><a href="#getting_started"><i class="icon-chevron-right"></i> Getting Started</a></li>
-              <li><a href="#field_guide"><i class="icon-chevron-right"></i> Field Guide</a></li>
-              <li><a href="#carrying_on"><i class="icon-chevron-right"></i> Carrying On</a></li>
+              <li><a href="#getting-started"><i class="icon-chevron-right"></i> Getting Started</a></li>
+              <li><a href="#field-guide"><i class="icon-chevron-right"></i> Field Guide</a></li>
+              <li><a href="#carrying-on"><i class="icon-chevron-right"></i> Carrying On</a></li>
            </ul>
           </div>
         </div>


### PR DESCRIPTION
Anchors had dashes while links had underscores, `#getting_started` vs `#getting-started`